### PR TITLE
Add extension recommendation for tutorialmaker

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "EclipseSource.tutorialmaker"
+  ]
+}


### PR DESCRIPTION
Works in environments, with access to OpenVSX Marketplace. To make it available also in local VS Code, extension needs to be published to VS Code Marketplace
Closes #6

Signed-off-by: Max Elia Schweigkofler <max_elia@hotmail.de>