### PR TITLE
Fix prebuild, add silently, fix exercises

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ ports:
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - prebuild: git clone https://github.com/eclipse-glsp/glsp-examples.git && cd glsp-examples/minimal/server/org.eclipse.glsp.example.minimal && mvn clean install && cd ../../client && yarn && cd ../../.. &&  mkdir -p ./glsp-examples/minimal/server/org.eclipse.glsp.example.minimal/src/test/java/org/eclipse/glsp/example/minimal/handler/ && cp .tutorial/test/TestMinimalCreateNodeOperationHandler.java ./glsp-examples/minimal/server/org.eclipse.glsp.example.minimal/src/test/java/org/eclipse/glsp/example/minimal/handler/ && cp .tutorial/pom.xml ./glsp-examples/minimal/server/org.eclipse.glsp.example.minimal/
+  - init: git clone https://github.com/eclipse-glsp/glsp-examples.git && cd glsp-examples/minimal/server/org.eclipse.glsp.example.minimal && mvn clean install && cd ../../client && yarn && cd ../../.. &&  mkdir -p ./glsp-examples/minimal/server/org.eclipse.glsp.example.minimal/src/test/java/org/eclipse/glsp/example/minimal/handler/ && cp .tutorial/test/TestMinimalCreateNodeOperationHandler.java ./glsp-examples/minimal/server/org.eclipse.glsp.example.minimal/src/test/java/org/eclipse/glsp/example/minimal/handler/ && cp .tutorial/pom.xml ./glsp-examples/minimal/server/org.eclipse.glsp.example.minimal/
 
 vscode:
   extensions:

--- a/.tutorial/glsp.tut.json
+++ b/.tutorial/glsp.tut.json
@@ -51,12 +51,12 @@
 						"commands": [
 							{
 								"terminalCommands": [
-									"kill -9 $(lsof -t -i:3000)",
-									"kill -9 $(lsof -t -i:5013)",
+									"silently kill -9 $(lsof -t -i:3000)",
+									"silently kill -9 $(lsof -t -i:5013)",
 									"git clone https://github.com/eclipse-glsp/glsp-examples.git",
 									"cd glsp-examples/minimal/server/org.eclipse.glsp.example.minimal && mvn clean install",
 									"cd glsp-examples/minimal/client && yarn",
-									"cd glsp-examples/minimal/client && yarn start:browser"
+									"silently cd glsp-examples/minimal/client && yarn start:browser"
 								]
 							}
 						]
@@ -71,9 +71,9 @@
 						"commands": [
 							{
 								"terminalCommands": [
-									"kill -9 $(lsof -t -i:3000)",
-									"kill -9 $(lsof -t -i:5013)",
-									"cd glsp-examples/minimal/client && yarn start:browser"
+									"silently kill -9 $(lsof -t -i:3000)",
+									"silently kill -9 $(lsof -t -i:5013)",
+									"silently cd glsp-examples/minimal/client && yarn start:browser"
 								]
 							}
 						]
@@ -122,9 +122,9 @@
 						"git clone https://github.com/eclipse-glsp/glsp-examples.git",
 						"cd glsp-examples/minimal/server/org.eclipse.glsp.example.minimal && mvn clean install",
 						"cd glsp-examples/minimal/client && yarn",
-						"kill -9 $(lsof -t -i:3000)",
-						"kill -9 $(lsof -t -i:5013)",
-						"cd glsp-examples/minimal/client && yarn start:browser"
+						"silently kill -9 $(lsof -t -i:3000)",
+						"silently kill -9 $(lsof -t -i:5013)",
+						"silently cd glsp-examples/minimal/client && yarn start:browser"
 					]
 				}
 			],
@@ -226,9 +226,9 @@
 								"terminalCommands": [
 									"cd glsp-examples/minimal/server/org.eclipse.glsp.example.minimal && mvn clean install",
 									"cd glsp-examples/minimal/client/minimal-theia && yarn copy:server",
-									"kill -9 $(lsof -t -i:3000)",
-									"kill -9 $(lsof -t -i:5013)",
-									"cd glsp-examples/minimal/client && yarn start:browser"
+									"silently kill -9 $(lsof -t -i:3000)",
+									"silently kill -9 $(lsof -t -i:5013)",
+									"silently cd glsp-examples/minimal/client && yarn start:browser"
 								]
 							}
 						]
@@ -277,7 +277,10 @@
 					"terminalCommands": [
 						"cp .tutorial/solution/MinimalCreateNodeOperationHandler.java glsp-examples/minimal/server/org.eclipse.glsp.example.minimal/src/main/java/org/eclipse/glsp/example/minimal/handler/MinimalCreateNodeOperationHandler.java",
 						"cd glsp-examples/minimal/server/org.eclipse.glsp.example.minimal && mvn clean install",
-						"cd glsp-examples/minimal/client/minimal-theia && yarn copy:server"
+						"cd glsp-examples/minimal/client/minimal-theia && yarn copy:server",
+						"silently kill -9 $(lsof -t -i:3000)",
+						"silently kill -9 $(lsof -t -i:5013)",
+						"silently cd glsp-examples/minimal/client && yarn start:browser"
 					]
 				}
 			]
@@ -414,10 +417,10 @@
 							{
 								"terminalCommands": [
 									"cd glsp-examples/minimal/server/org.eclipse.glsp.example.minimal && mvn clean install",
-									"cd glsp-examples/minimal/client/minimal-theia && yarn",
-									"kill -9 $(lsof -t -i:3000)",
-									"kill -9 $(lsof -t -i:5013)",
-									"cd glsp-examples/minimal/client && yarn start:browser"
+									"cd glsp-examples/minimal/client && yarn",
+									"silently kill -9 $(lsof -t -i:3000)",
+									"silently kill -9 $(lsof -t -i:5013)",
+									"silently cd glsp-examples/minimal/client && yarn start:browser"
 								]
 							}
 						]

--- a/.tutorial/solution/MinimalCreateNewNodeOperationHandler.java
+++ b/.tutorial/solution/MinimalCreateNewNodeOperationHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 EclipseSource and others.
+ * Copyright (c) 2020 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,7 +17,6 @@ package org.eclipse.glsp.example.minimal.handler;
 
 import java.util.Optional;
 
-import org.eclipse.glsp.graph.DefaultTypes;
 import org.eclipse.glsp.graph.GNode;
 import org.eclipse.glsp.graph.GPoint;
 import org.eclipse.glsp.graph.builder.impl.GNodeBuilder;

--- a/.tutorial/solution/MinimalGLSPModule.java
+++ b/.tutorial/solution/MinimalGLSPModule.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 EclipseSource and others.
+ * Copyright (c) 2020 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/.tutorial/solution/di.config.ts
+++ b/.tutorial/solution/di.config.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 EclipseSource and others.
+ * Copyright (c) 2020 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,11 +13,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import "../css/diagram.css";
+import '../css/diagram.css';
 
 import {
     boundsModule,
     buttonModule,
+    CircularNode,
+    CircularNodeView,
     configureModelElement,
     ConsoleLogger,
     defaultGLSPModule,
@@ -41,8 +43,6 @@ import {
     paletteModule,
     RectangularNode,
     RectangularNodeView,
-    CircularNode,
-    CircularNodeView,
     routingModule,
     SGraphView,
     toolFeedbackModule,
@@ -51,8 +51,8 @@ import {
     validationModule,
     viewportModule,
     zorderModule
-} from "@eclipse-glsp/client";
-import { Container, ContainerModule } from "inversify";
+} from '@eclipse-glsp/client';
+import { Container, ContainerModule } from 'inversify';
 
 const minimalDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();


### PR DESCRIPTION
- Use init option instead of prebuild in gitpod.yml (prebuild is deprecated), fixes #10
- Add "silently" option to "kill" commands and not terminating commands (starting server), fixes #11, fixes #13
  - (This change depends on updated tutorial-maker extension)
- Correct build command for last solution step, fixes #17
- Use same format and year as in upstream for solution, fixes #15

Signed-off-by: Max Elia Schweigkofler <max_elia@hotmail.de>