### PR TITLE
copy LSP jar upon rebuild

### DIFF
--- a/.tutorial/glsp.tut.json
+++ b/.tutorial/glsp.tut.json
@@ -427,7 +427,7 @@
 							{
 								"terminalCommands": [
 									"cd glsp-examples/minimal/server/org.eclipse.glsp.example.minimal && mvn clean install",
-									"cd glsp-examples/minimal/client && yarn",
+									"cd glsp-examples/minimal/client/minimal-theia && yarn copy:server",
 									"silently kill -9 $(lsof -t -i:3000)",
 									"silently kill -9 $(lsof -t -i:5013)",
 									"silently cd glsp-examples/minimal/client && yarn start:browser"


### PR DESCRIPTION
Hi, 

i noticed that in the last step of the tutorial (adding a new node type) the re-build commands list is missing the copy LSP jar logic.
Therefore the new node type won't ever appear in the palette if the user just clicks the re-build button in the tutorial view.

Greetings, 
Alex